### PR TITLE
Return "target_temperature" as "None" when summer mode is ON

### DIFF
--- a/pybmr/__init__.py
+++ b/pybmr/__init__.py
@@ -218,7 +218,12 @@ class Bmr:
             pass
 
         try:
-            result["target_temperature"] = float(room_status["target_temperature"])
+            # If summer mode is turned on (which means the system is powered
+            # down) we will return target temperature as `None`, not 0 degrees
+            if not bool(int(room_status["summer_mode"])):
+                result["target_temperature"] = float(room_status["target_temperature"])
+            else:
+                result["target_temperature"] = None
         except ValueError:
             pass
 


### PR DESCRIPTION
Hey,,

I made a slight change in how the target temperature is handled in summer mode. I think it makes more sense to report the circuit target temperature as `None` when summer mode is turned on, instead of `0`.

This also has a "nice" side-effect that you won't see the target temperature `0` in graphs in HA (but also in Grafana). Without this patch the vertical temperature axis would have range from 0 to around 25 C (in my case) and because of that the temperature graph is basically a flat line.