### PR TITLE
Fix exception in getCircuit() caused by malformed response

### DIFF
--- a/pybmr/__init__.py
+++ b/pybmr/__init__.py
@@ -205,15 +205,25 @@ class Bmr:
             "target_temperature": None,
             "user_offset": None,
             "max_offset": None,
-            "heating": bool(int(room_status["heating"])),
+            "heating": False,
             "warning": int(room_status["warning"]),
-            "cooling": bool(int(room_status["cooling"])),
+            "cooling": False,
             "low_mode": bool(int(room_status["low_mode"])),
             "summer_mode": bool(int(room_status["summer_mode"])),
         }
 
         try:
             result["temperature"] = float(room_status["temperature"])
+        except ValueError:
+            pass
+
+        try:
+            result["heating"] = bool(int(room_status["heating"]))
+        except ValueError:
+            pass
+
+        try:
+            result["cooling"] = bool(int(room_status["cooling"]))
         except ValueError:
             pass
 


### PR DESCRIPTION
Sometimes BMR controller sends "-" instead of int.

```
  Traceback (most recent call last):
    File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 278, in async_update_ha_state
      await self.async_device_update()
    File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 474, in async_device_update
      raise exc
    File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/usr/src/homeassistant/homeassistant/util/__init__.py", line 259, in wrapper
      result = method(*args, **kwargs)
    File "/config/custom_components/bmr/sensor.py", line 110, in update
      circuit = self._bmr.getCircuit(self._config.get(CONF_CIRCUIT_ID))
    File "/usr/local/lib/python3.8/site-packages/cachetools/func.py", line 64, in wrapper
      v = func(*args, **kwargs)
    File "/config/pybmr/__init__.py", line 47, in wrapped
      return func(self, *args, **kwargs)
    File "/config/pybmr/__init__.py", line 208, in getCircuit
      "heating": bool(int(room_status["heating"])),
     ValueError: invalid literal for int() with base 10: '-'
``` 