### PR TITLE
Fix more exceptions in getCircuit() caused by malformed responses

### DIFF
--- a/pybmr/__init__.py
+++ b/pybmr/__init__.py
@@ -206,26 +206,26 @@ class Bmr:
             "user_offset": None,
             "max_offset": None,
             "heating": False,
-            "warning": int(room_status["warning"]),
+            "warning": 0,
             "cooling": False,
-            "low_mode": bool(int(room_status["low_mode"])),
-            "summer_mode": bool(int(room_status["summer_mode"])),
+            "low_mode": False,
+            "summer_mode": False,
         }
 
-        try:
-            result["temperature"] = float(room_status["temperature"])
-        except ValueError:
-            pass
-
-        try:
-            result["heating"] = bool(int(room_status["heating"]))
-        except ValueError:
-            pass
-
-        try:
-            result["cooling"] = bool(int(room_status["cooling"]))
-        except ValueError:
-            pass
+        for key in (
+            "temperature",
+            "heating",
+            "cooling",
+            "warning",
+            "low_mode",
+            "summer_mode",
+            "user_offset",
+            "max_offset",
+        ):
+            try:
+                result[key] = float(room_status[key])
+            except ValueError:
+                pass
 
         try:
             # If summer mode is turned on (which means the system is powered
@@ -234,16 +234,6 @@ class Bmr:
                 result["target_temperature"] = float(room_status["target_temperature"])
             else:
                 result["target_temperature"] = None
-        except ValueError:
-            pass
-
-        try:
-            result["user_offset"] = float(room_status["user_offset"])
-        except ValueError:
-            pass
-
-        try:
-            result["max_offset"] = float(room_status["max_offset"])
         except ValueError:
             pass
 


### PR DESCRIPTION
E.g.

  2021-03-16 10:29:44 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.bmr_hc64_corridor_temperature fails
  Traceback (most recent call last):
    File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 278, in async_update_ha_state
      await self.async_device_update()
    File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 474, in async_device_update
      raise exc
    File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/usr/src/homeassistant/homeassistant/util/__init__.py", line 259, in wrapper
      result = method(*args, **kwargs)
    File "/config/custom_components/bmr/sensor.py", line 110, in update
      circuit = self._bmr.getCircuit(self._config.get(CONF_CIRCUIT_ID))
    File "/usr/local/lib/python3.8/site-packages/cachetools/func.py", line 64, in wrapper
      v = func(*args, **kwargs)
    File "/config/pybmr/__init__.py", line 47, in wrapped
      return func(self, *args, **kwargs)
    File "/config/pybmr/__init__.py", line 209, in getCircuit
      "warning": int(room_status["warning"]),
  ValueError: invalid literal for int() with base 10: '1-1'